### PR TITLE
Add deoplete support

### DIFF
--- a/autoload/elixircomplete.vim
+++ b/autoload/elixircomplete.vim
@@ -8,12 +8,11 @@ let s:erlang_module= ':\<'
 let s:elixir_fun_w_arity = '.*/[0-9]$'
 let s:elixir_module = '[A-Z][[:alnum:]_]\+\([A_Z][[:alnum:]_]+\)*'
 
-
-function! elixircomplete#Complete(findstart, base)
+function! elixircomplete#Complete(findstart, base_or_suggestions)
     if a:findstart
         return s:FindStart()
     else
-        return s:build_completions(a:base)
+        return s:build_completions(a:base_or_suggestions)
     endif
 endfunction
 
@@ -39,8 +38,14 @@ function! s:FindStart()
     return pos
 endfunction
 
-function! s:build_completions(base)
-    let suggestions = elixircomplete#get_suggestions(a:base)
+
+function! s:build_completions(base_or_suggestions)
+    if type(a:base_or_suggestions) == type([])
+      let suggestions = a:base_or_suggestions
+    else
+      let suggestions = elixircomplete#get_suggestions(a:base_or_suggestions)
+    endif
+
     if len(suggestions) == 0
         return -1
     elseif len(suggestions) == 1

--- a/rplugin/python3/deoplete/sources/alchemist.py
+++ b/rplugin/python3/deoplete/sources/alchemist.py
@@ -1,0 +1,44 @@
+import os
+from numbers import Number
+from subprocess import PIPE, Popen
+from .base import Base
+
+class Source(Base):
+    ALCHEMIST_CLIENT   = 'g:alchemist#alchemist_client'
+    ALCHEMIST_FORMAT   = 'alchemist#alchemist_format'
+    ALCHEMIST_COMPLETE = 'elixircomplete#Complete'
+
+    def __init__(self, vim):
+        Base.__init__(self, vim)
+
+        self.name = 'alchemist'
+        self.mark = '[alchemist]'
+        self.filetypes = ['elixir']
+        self.is_bytepos = False
+        self.min_pattern_length = 0
+
+    def get_complete_position(self, context):
+        return self.vim.call('elixircomplete#Complete', 1, '')
+
+    def gather_candidates(self, context):
+        client  = self.__get_client__()
+        request = self.__get_request__(context['complete_str']).encode()
+        cwd_opt = '-d{0}'.format(os.getcwd())
+
+        with Popen([client, cwd_opt], stdin=PIPE, stdout=PIPE) as proc:
+            results = proc.communicate(input=request)[0].decode()
+
+        return self.__get_suggestions__(results.split('\n')[:-2])
+
+    # Private implementation
+    ########################
+
+    def __get_client__(self):
+        return self.vim.eval(self.ALCHEMIST_CLIENT)
+
+    def __get_request__(self, input):
+        return self.vim.call(self.ALCHEMIST_FORMAT, 'COMP', input, 'Elixir', [], [])
+
+    def __get_suggestions__(self, server_results):
+        suggestions = self.vim.call(self.ALCHEMIST_COMPLETE, 0, server_results)
+        return [] if isinstance(suggestions, Number) else suggestions


### PR DESCRIPTION
Hi there,

This pull request is to add support for [Shougo's deoplete.nvim](https://github.com/Shougo/deoplete.nvim/), and therefore allow realtime, asynchronous completion while typing, with alchemist.vim!

[![asciicast](https://asciinema.org/a/9uupb79bp90p9ji4jbfolvzuk.png)](https://asciinema.org/a/9uupb79bp90p9ji4jbfolvzuk)

Because of the asynchronous nature of deoplete, I had to do a couple of small changes to `elixircomplete.vim`, that are completely backwards-compatible: allow `elixircomplete#Complete`'s caller to pass in an already computed list of suggestions. These suggestions are calculated from deoplete's python environment, guaranteeing smooth typing. 

I initially tried to keep it simpler and just call `elixircomplete#Complete` with the initial string, but it gave a bad sluggish feeling to the cursor. Hopefully there isn't much duplication this way, as almost all calls are made to the original methods.

Thanks a million for making this, enjoying it so far!
