### PR TITLE
restore default min_pattern_length for deoplete

### DIFF
--- a/rplugin/python3/deoplete/sources/alchemist.py
+++ b/rplugin/python3/deoplete/sources/alchemist.py
@@ -15,7 +15,6 @@ class Source(Base):
         self.mark = '[alchemist]'
         self.filetypes = ['elixir']
         self.is_bytepos = False
-        self.min_pattern_length = 0
 
     def get_complete_position(self, context):
         return self.vim.call('elixircomplete#Complete', 1, '')


### PR DESCRIPTION
![Image](http://i.lvme.me/gj224xt.jpg)

Hey there,

This is to remove a `min_pattern_length = 0` that triggers deoplete all the time. While nice for learning Elixir, it can get frustrating, so I think it's better if we leave it to the user to set this value, via the `g:deoplete#auto_complete_start_length` variable.

Cheers!
