### PR TITLE
Added Mix task support

### DIFF
--- a/after/ftplugin/elixir.vim
+++ b/after/ftplugin/elixir.vim
@@ -26,3 +26,5 @@ endif
 
 nnoremap <silent> K :call alchemist#lookup_name_under_cursor()<CR>
 command! -nargs=? ExDoc call alchemist#exdoc(<f-args>)
+command! -buffer -bar -nargs=? -complete=custom,alchemist#mix_complete Mix
+    \ call alchemist#mix(<q-args>)

--- a/after/ftplugin/elixir.vim
+++ b/after/ftplugin/elixir.vim
@@ -26,5 +26,7 @@ endif
 
 nnoremap <silent> K :call alchemist#lookup_name_under_cursor()<CR>
 command! -nargs=? ExDoc call alchemist#exdoc(<f-args>)
-command! -buffer -bar -nargs=? -complete=custom,alchemist#mix_complete Mix
-    \ call alchemist#mix(<q-args>)
+if !exists(':Mix')
+  command! -buffer -bar -nargs=? -complete=custom,alchemist#mix_complete Mix
+        \ call alchemist#mix(<q-args>)
+endif

--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -239,3 +239,14 @@ function! alchemist#get_import(line)
     end
     return ''
 endfunction
+
+function! alchemist#mix(...)
+  exe '!mix ' . join(copy(a:000), ' ')
+endfunction
+
+function! alchemist#mix_complete(ArgLead, CmdLine, CursorPos, ...)
+  if !exists('g:mix_tasks')
+    let g:mix_tasks = system("mix -h | awk '!/-S/ && $2 != \"#\" { print $2 }'")
+  endif
+  return g:mix_tasks
+endfunction


### PR DESCRIPTION
First off, I started using your plugin the other day - it's excellent :heart:
From looking at your todo list #1 I saw that support for mix tasks was on the list.

This change adds an Ex command - `:Mix` for running mix tasks from Vim.

e.g. `:Mix deps.get` --> '!mix deps.get'

It supports basic tab completion - by parsing the output of `mix -h`.
e.g. `:Mix d<tab>` --> `:Mix deps`

Was this the kind of thing you had in mind with regards to support for mix tasks?

Thanks again for the awesome plugin :heart:
