### PR TITLE
Enable Mix command in all buffers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 Helium (2.X.X)
 
+v 2.0.1
+	- Mix command is available on all buffers (bugfix)
+
 v 2.0.0
 	- use absolute path of project directory
 	- detect project base dir based on running servers or locating mix.exs

--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -263,6 +263,6 @@ command! -nargs=? -complete=customlist,elixircomplete#ExDocComplete ExDoc
       \ call alchemist#exdoc(<f-args>)
 
 if !exists(':Mix')
-  command! -buffer -bar -nargs=? -complete=custom,alchemist#mix_complete Mix
+  command! -bar -nargs=? -complete=custom,alchemist#mix_complete Mix
         \ call alchemist#mix(<q-args>)
 endif


### PR DESCRIPTION
Mix command is only available on the first opened buffer with this change it is available in all buffers

I'm not familiar with `command` options, do you remember the reason that you used `-buffer`?
