### PR TITLE
IEx Integration

### DIFF
--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -256,10 +256,10 @@ endif
 if !exists('g:alchemist_iex_term_split')
   let g:alchemist_iex_term_split = "split"
 endif
-if exists('g:ConqueTerm_Loaded')
-  let s:alchemist_iex_runner = "ConqueTerm"
-elseif has('nvim')
+if has('nvim')
   let s:alchemist_iex_runner = "terminal"
+elseif exists('g:ConqueTerm_Loaded')
+  let s:alchemist_iex_runner = "ConqueTerm"
 endif
 
 function! s:iex_open_cmd()
@@ -303,7 +303,11 @@ function! alchemist#open_iex(command)
   else
     " no IEx buffer exists, open a new one
     exec s:iex_open_cmd()
-    exec s:alchemist_iex_runner . " iex -S mix"
+    if filereadable('mix.exs')
+      exec s:alchemist_iex_runner . " iex -S mix"
+    else
+      exec s:alchemist_iex_runner . " iex"
+    endif
     let s:alchemist_iex_buffer = bufnr("%")
     call s:iex_enter_user_command(a:command, '')
   endif

--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -285,14 +285,14 @@ function! alchemist#open_iex(command)
     return ""
   endif
   if s:iex_buffer_exists()
-    let bufno = bufwinnr(s:alchemist_iex_buffer)
+    let winno = bufwinnr(s:alchemist_iex_buffer)
     " if IEx is the current buffer and no command was passed, hide it
-    if bufno == bufnr("%") && empty(a:command)
+    if s:alchemist_iex_buffer == bufnr("%") && empty(a:command)
       call alchemist#hide_iex()
 
     " if the buffer is in an open window, switch to it
-    elseif bufno != -1
-      exec bufno . "wincmd w"
+    elseif winno != -1
+      exec winno . "wincmd w"
       call s:iex_enter_user_command(a:command, 'i')
 
     " otherwise the buffer is hidden, open it in a new window


### PR DESCRIPTION
Added support for IEx shell within vim - requires either Neovim or
ConqueShell. For ConqueShell - the setting `g:ConqueTerm_CloseOnEnd`
should be enabled to properly exit IEx.

There are two new commands:
- `:IEx {command}`
- `:IExHide`

`:IEx` opens a new IEx session if none exists (iex -S mix). If one
already exists, it switches to that window (or reopens the window if it
was closed).
`:IEx` can take a command, which it will run. For example:
`:IEx h Enum.reverse`

`:IEx` also has <tab> completion - using the same completion function as
`:ExDoc` uses.

`:IEx` opens a new horizontal split for the IEx session. The size of the
split can be configured by changing `g:alchemist_iex_term_size`.
Similarly, the horizontal split can be changed to vertical by changing
`g:alchemist_iex_term_split` - either `split` or `vsplit` are valid
values.

`:IExHide` hides the window that the IEx session is in.
