### PR TITLE
Tags

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 Helium (2.X.X)
 
+v 2.1.0
+	- implement ExDef to jump to the definition.
+	- map CTRL-] to jump to the definition of the keyword under the cursor
+	- map CTRL-T Jump to older entry in the tag stack.
+	- support alias for erlang modules.
+
 v 2.0.0
 	- use absolute path of project directory
 	- detect project base dir based on running servers or locating mix.exs

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This plugin uses [alchemist-server](https://github.com/tonini/alchemist-server) 
 
 * Completion for Modules and functions.
 * Documentation lookup for Modules and functions.
+* Jump to the definition.
 
 [More supports will come soon](https://github.com/slashmili/alchemist.vim/issues/1)
 
@@ -47,12 +48,15 @@ Go to your elixir project directory and run `vim`
 ### Shortkeys:
 
   * Auto completion: `<C-x><C-o>` while your are in `INSERT` mode.
-  * Documention: Press `K` while cursor is under a module or function in `NORMAL`.
+  * Documention: Press `K` while cursor is under a module or function in `NORMAL` mode.
+  * Jump to the definition: Press `<C-]>` while cursor is under the keyword in `NORMAL` mode.
+  * Jump through tag stack: Press `<C-T>` to jump between tag stack in `NORMAL` mode.
 
 ### Commands:
 
   * ExDoc: `ExDoc [module/function]` provides document (press TAB to get autocomplete).
   * Mix: `Mix [command]` run mix command (press TAB to get commands autocomplete). If you already have an existing `Mix` command, alchemist doesn't define this command.
+  * ExDef: `ExDef [module/function]` jumps to the definition.
 
 ### Demo
 

--- a/after/ftplugin/elixir.vim
+++ b/after/ftplugin/elixir.vim
@@ -26,5 +26,15 @@ endif
 
 nnoremap <silent> K :call alchemist#exdoc()<CR>
 
-nnoremap <silent> <c-]> :call alchemist#exdef()<CR>
 command! -nargs=? ExDef call alchemist#exdef(<f-args>)
+
+if !exists('g:alchemist_tag_disable')
+    if !exists('g:alchemist_tag_map') | let g:alchemist_tag_map = '<C-]>' | en
+    if !exists('g:alchemist_tag_stack_map') | let g:alchemist_tag_stack_map = '<C-T>' | en
+    if g:alchemist_tag_map != '' && !hasmapto('alchemist#exdef()')
+        exe 'nnoremap <silent> ' . g:alchemist_tag_map . ' :call alchemist#exdef()<CR>'
+    endif
+    if g:alchemist_tag_stack_map != '' && !hasmapto('alchemist#jump_tag_stack()')
+        exe 'nnoremap <silent> ' . g:alchemist_tag_stack_map . ' :call alchemist#jump_tag_stack()<CR>'
+    endif
+endif

--- a/after/ftplugin/elixir.vim
+++ b/after/ftplugin/elixir.vim
@@ -24,7 +24,7 @@ if exists('&omnifunc') && g:alchemist#omnifunc
   setl omnifunc=elixircomplete#Complete
 endif
 
-nnoremap <silent> K :call alchemist#lookup_name_under_cursor()<CR>
+nnoremap <silent> K :call alchemist#exdoc()<CR>
 
 nnoremap <silent> <c-]> :call alchemist#exdef()<CR>
 command! -nargs=? ExDef call alchemist#exdef(<f-args>)

--- a/after/ftplugin/elixir.vim
+++ b/after/ftplugin/elixir.vim
@@ -26,3 +26,6 @@ endif
 
 nnoremap <silent> K :call alchemist#exdoc()<CR>
 command! -nargs=? ExDoc call alchemist#exdoc(<f-args>)
+
+nnoremap <silent> <c-]> :call alchemist#exdef()<CR>
+command! -nargs=? ExDef call alchemist#exdef(<f-args>)

--- a/after/ftplugin/elixir.vim
+++ b/after/ftplugin/elixir.vim
@@ -24,5 +24,5 @@ if exists('&omnifunc') && g:alchemist#omnifunc
   setl omnifunc=elixircomplete#Complete
 endif
 
-nnoremap <silent> K :call alchemist#lookup_name_under_cursor()<CR>
+nnoremap <silent> K :call alchemist#exdoc()<CR>
 command! -nargs=? ExDoc call alchemist#exdoc(<f-args>)

--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -14,11 +14,15 @@ end
 
 function! alchemist#alchemist_client(req)
     let req = a:req . "\n"
-    let ansi = ""
+    let cmd = g:alchemist#alchemist_client
     if !alchemist#ansi_enabled()
-        let ansi = '--colors=false'
+        let cmd = cmd . ' --colors=false '
     endif
-    return system(g:alchemist#alchemist_client. ' ' . ansi  . ' -d ' . g:alchemist#root, req)
+    if exists('g:alchemist#elixir_erlang_src')
+        let cmd = cmd . ' -s ' . g:alchemist#elixir_erlang_src
+    endif
+    let cmd = cmd . ' -d ' . g:alchemist#root
+    return system(cmd, req)
 endfunction
 
 function! alchemist#get_doc(word)

--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -171,26 +171,26 @@ function! alchemist#exdef(...)
         let query = a:000[0]
     endif
     if s:strip(query) == ''
-        echo "Alchemist: No module/function is provided"
+        call s:echo_error('E426: tag not found: ')
         return
     endif
     let req = alchemist#alchemist_format("DEFLX", query, "Elixir", [], [])
     let result = alchemist#alchemist_client(req)
-    let source = filter(split(result, '\n'), 'v:val != "END-OF-DEFLX"')
-    if len(source) == 0
-        echo "Alchemist: Can not find any source for " . query
+    let source_match = filter(split(result, '\n'), 'v:val != "END-OF-DEFLX"')
+    if len(source_match) == 0
+        call s:echo_error('E426: tag not found: ' . query)
         return
     endif
-    let source = source[0]
+    let source_file = source_match[0]
     let line = 1
-    let source_line = matchlist(source, '\(.*\):\([0-9]\+\)')
-    if len(source_line) > 0
-        let source = source_line[1]
-        let line = source_line[2]
+    let source_and_line = matchlist(source_file, '\(.*\):\([0-9]\+\)')
+    if len(source_and_line) > 0
+        let source_file = source_and_line[1]
+        let line = source_and_line[2]
     endif
-    let rel_path = substitute(source, getcwd() . '/' , '', '')
+    let rel_path = substitute(source_file, getcwd() . '/' , '', '')
     if !filereadable(rel_path)
-        echo "Alchemist: Can not open file " . rel_path
+        call s:echo_error("E484: Can't open file: " . rel_path)
         return
     endif
     execute 'e ' . rel_path
@@ -199,6 +199,12 @@ endfunction
 
 function! s:strip(input_string)
     return substitute(a:input_string, '^\s*\(.\{-}\)\s*$', '\1', '')
+endfunction
+
+function! s:echo_error(text)
+	echohl ErrorMsg
+	echo a:text
+	echohl None
 endfunction
 
 function! alchemist#get_current_module_details()

--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -224,9 +224,9 @@ function! s:strip(input_string)
 endfunction
 
 function! s:echo_error(text)
-	echohl ErrorMsg
-	echo a:text
-	echohl None
+    echohl ErrorMsg
+    echo a:text
+    echohl None
 endfunction
 
 function! alchemist#get_current_module_details()

--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -173,12 +173,20 @@ function! alchemist#exdef(...)
         echo "Alchemist: Can not find any source for " . query
         return
     endif
-    let rel_path = substitute(source[0], getcwd() . '/' , '', '')
+    let source = source[0]
+    let line = 1
+    let source_line = matchlist(source, '\(.*\):\([0-9]\+\)')
+    if len(source_line) > 0
+        let source = source_line[1]
+        let line = source_line[2]
+    endif
+    let rel_path = substitute(source, getcwd() . '/' , '', '')
     if !filereadable(rel_path)
         echo "Alchemist: Can not open file " . rel_path
         return
     endif
     execute 'e ' . rel_path
+    execute line
 endfunction
 
 function! s:strip(input_string)

--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -87,7 +87,7 @@ function! alchemist#lookup_name_under_cursor()
     else
         let query = before . after
     endif
-    call s:open_doc_window(query, 'new', 'split')
+    return query
 endfunction
 
 function! s:open_doc_window(query, newposition, position)
@@ -146,11 +146,13 @@ function! s:close_doc_win()
 endfunction
 
 function! alchemist#exdoc(...)
+    let query = ''
     if empty(a:000)
-        call alchemist#lookup_name_under_cursor()
-        return
+        let query = alchemist#lookup_name_under_cursor()
+    else
+        let query = a:000[0]
     endif
-    call s:open_doc_window(a:000[0], "new", "split")
+    call s:open_doc_window(query, "new", "split")
 endfunction
 
 function! s:strip(input_string)

--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -72,7 +72,8 @@ function! alchemist#lookup_name_under_cursor()
 
     let before_cursor = strpart(getline('.'), 0, col('.'))
     let after_cursor = strpart(getline('.'), col('.'))
-    let before_match = matchlist(before_cursor, s:module_func_match . '$')
+    let elixir_erlang_module_func_match = ':\?' . s:module_func_match
+    let before_match = matchlist(before_cursor, elixir_erlang_module_func_match . '$')
     let after_match = matchlist(after_cursor, '^' . s:module_func_match)
     let query = ''
     let before = ''

--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -1,5 +1,5 @@
 let s:buf_nr = -1
-let s:module_match = '[A-Za-z0-9\._]\+'
+let s:module_match = '[:A-Za-z0-9\._]\+'
 let s:module_func_match = '[A-Za-z0-9\._?!]\+'
 let g:alchemist_tag_stack = []
 let g:alchemist_tag_stack_is_used = 0
@@ -50,8 +50,8 @@ function! alchemist#alchemist_format(cmd, arg, context, imports, aliases)
     "remove '
     let aliases_str = substitute(aliases_str, "'", '', 'g')
     let imports_str = substitute(imports_str, "'", '', 'g')
-    "replace : to ,
-    let aliases_str = substitute(aliases_str, ":", ',', 'g')
+    "replace key: to key,
+    let aliases_str = substitute(aliases_str, ": ", ', ', 'g')
 
     return a:cmd. " { \"" . a:arg . "\", [ context: ". a:context.
                           \ ", imports: ". imports_str .

--- a/alchemist.py
+++ b/alchemist.py
@@ -199,6 +199,10 @@ class AlchemistClient:
         'ExGuard.Guard,guard'
         >>> alchemist._defl_extract_module_func("execute")
         ',execute'
+        >>> alchemist._defl_extract_module_func(":timer.sleep")
+        ':timer,sleep'
+        >>> alchemist._defl_extract_module_func(":timer")
+        ':timer,nil'
         """
         func = 'nil'
         module = query
@@ -210,6 +214,10 @@ class AlchemistClient:
         elif query.islower():
             func = query
             module = ''
+        if func[0] == ':':
+            #TODO: to improve this part
+            module, func = func, 'nil'
+
         return '%s,%s' % (module, func)
 
     def _sock_readlines(self, sock, recv_buffer=4096, delim='\n', timeout=10):

--- a/alchemist.py
+++ b/alchemist.py
@@ -182,7 +182,10 @@ class AlchemistClient:
         for line_num, line_str in enumerate(lines):
             if line_str.find("def %s" % function) != -1:
                 return line_num + 1
+            if line_str.find("defp %s" % function) != -1:
+                return line_num + 1
         return 1
+
     def _defl_extract_module_func(self, query):
         """
         >>> alchemist = AlchemistClient()

--- a/alchemist.py
+++ b/alchemist.py
@@ -169,7 +169,10 @@ class AlchemistClient:
         if len(module_func_list) == 2:
             if module_func_list[1] != "nil":
                 line = self._find_function_line(result.strip(), module_func_list[1])
-        result = "%s:%i\n%s" %(result.strip(), line, 'END-OF-DEFLX')
+        if result.strip() != '':
+            result = "%s:%i\n%s" %(result.strip(), line, 'END-OF-DEFLX')
+        else:
+            result = 'END-OF-DEFLX'
         return result
 
     def _find_function_line(self, filename, function):

--- a/alchemist.py
+++ b/alchemist.py
@@ -197,6 +197,8 @@ class AlchemistClient:
         'ExGuard.Guard,nil'
         >>> alchemist._defl_extract_module_func("ExGuard.Guard.guard")
         'ExGuard.Guard,guard'
+        >>> alchemist._defl_extract_module_func("execute")
+        ',execute'
         """
         func = 'nil'
         module = query
@@ -205,6 +207,9 @@ class AlchemistClient:
         if match:
             func = match.group('func')
             module = match.group('module')
+        elif query.islower():
+            func = query
+            module = ''
         return '%s,%s' % (module, func)
 
     def _sock_readlines(self, sock, recv_buffer=4096, delim='\n', timeout=10):

--- a/alchemist_client
+++ b/alchemist_client
@@ -16,6 +16,7 @@ def alchemist_help():
     -t, --command-type=""      Command type, if it's not provided, extract it from command
     -d, --directory=           Directory that alchemist server should process code from
     -a, --alchemist-server=""  Path to alchemist server `run.exs`, if it's not provided load it from alchemist-server/run.exs
+    -s, --source=""            Path to source code for Erlang and Elixir. It's used to find the path in DEFLX command
     --colors=true              Enable/Disable ansi
     """
 
@@ -25,8 +26,9 @@ def main(argv):
     cwd = ""
     alchemist_script = ""
     ansi = True
+    source = ""
     try:
-        opts, args = getopt.getopt(argv,"hc:t:d:a:",["type=","command-type=", "directory=", "alchemist-server=", "colors="])
+        opts, args = getopt.getopt(argv,"hc:t:d:a:s:",["type=","command-type=", "directory=", "alchemist-server=", "colors=", "source="])
     except getopt.GetoptError:
         print(alchemist_help())
         sys.exit(2)
@@ -42,6 +44,8 @@ def main(argv):
             cwd = arg
         elif opt in ("-a", "--alchemist-server"):
             alchemist_script = arg
+        elif opt in ("-s", "--source"):
+            source = arg
         elif opt in ("--colors"):
             if arg == "false":
                 ansi = False
@@ -62,7 +66,7 @@ def main(argv):
         print(alchemist_help())
         sys.exit(2)
 
-    a = AlchemistClient(debug=debug, cwd=cwd, ansi=ansi, alchemist_script=alchemist_script)
+    a = AlchemistClient(debug=debug, cwd=cwd, ansi=ansi, alchemist_script=alchemist_script, source=source)
     print(a.process_command(cmd), end="")
 
 


### PR DESCRIPTION
Ctr-] jump to definition
Ctr-T jump through tag stack

For jumping to definition on elixir and erlang code it needs extra configuration:
g:alchemist#elixir_erlang_src should be set in vim config, if it exists, it's passed to
alchemist_client as --source option and it's used to open elixir/erlang
source code. The variable should be like this:

let g:alchemist#elixir_erlang_src = "/home/foo/src/"

And this directory should contains two directories, elixir and otp
/home/foo/src/
├── elixir
│ ├── CHANGELOG.md
│ ├── lib
│ ├── Makefile
│ ├── ...
├── otp
│ ├── AUTHORS
│ ├── lib
│ │ ├── asn1
│ │ ├── stdlib
│ │ ├── ...
│ ├── ...
