### PR TITLE
ExDoc Colors

### DIFF
--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -28,6 +28,10 @@ endfunction
 function! alchemist#get_doc(word)
     let req = alchemist#alchemist_format("DOCL", a:word, "Elixir", [], [])
     let result = alchemist#alchemist_client(req)
+    " fix heading colors
+    let result = substitute(result, '\e\[7m\e\[33m', '[1m[33m', 'g')
+    " fix code example colors
+    let result = substitute(result, '\e\[36m\e\[1m', '[1m[36m', 'g')
     return result
 endfunction
 


### PR DESCRIPTION
A bit of a hack to fix the ansi colors in `ExDoc` lookup.
Previously the headings and code snippets had white font with colored
background. Now they have coloured font on regular background.

<img width="1361" alt="screen shot 2016-04-13 at 20 05 26" src="https://cloud.githubusercontent.com/assets/8920322/14505932/27fce176-01b3-11e6-9a50-8cb29da0398e.png">
