### PR TITLE
Quote cwd to prevent arguments from splitting

### DIFF
--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -17,7 +17,7 @@ function! alchemist#alchemist_client(req)
     if exists('g:alchemist#elixir_erlang_src')
         let cmd = cmd . ' -s ' . g:alchemist#elixir_erlang_src
     endif
-    let cmd = cmd . ' -d ' . expand('%:p:h')
+    let cmd = cmd . ' -d "' . expand('%:p:h') . '"'
 
     return system(cmd, req)
 endfunction


### PR DESCRIPTION
Quote the working directory before passing it as a command-line parameter to prevent directories with space in them to count as several parameters.