### PR TITLE
configurable current working directory

### DIFF
--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -216,7 +216,8 @@ function! alchemist#exdef(...)
         let source_file = source_and_line[1]
         let line = source_and_line[2]
     endif
-    let rel_path = substitute(source_file, getcwd() . '/' , '', '')
+    let current_working_dir = get(g:, 'alchemist_current_working_dir', getcwd() . '/')
+    let rel_path = substitute(source_file, current_working_dir, '', '')
     if !filereadable(rel_path)
         call s:echo_error("E484: Can't open file: " . rel_path)
         return


### PR DESCRIPTION
I have the following usecase.
My development environment is dockerized, but my VIM is in my host machine (using volumes to mount the code) 
When I run Ctrl-] to jump to a definition, the file is never found, because the paths used are the ones where the project was compiled (that is, inside docker).
If I print the results of the getcwd and the detected source file inside `function! alchemist#exdef(...) `, I get the following:
```
getcwd: /Users/juan/workspace/sylar
source_file: /app/web/controllers/category_controller.ex
```
when trying to convert the source_file to relative_path, the transformation is:
`let rel_path = substitute(source_file, getcwd(). '/', '', '')`
because of this mismatch, the rel_path will always be the same as source_file.

What i'm proposing here is to add a configurable variable, that will take precedence over the getcwd() function.
With this change, I could set the variable with the value of '/app/' and then the calculation of rel_path would be correct, as I would be setting it to the base path of the project inside the docker container.

I'm not sure if this is the right approach for your project. But I would love your feedback on it