### PR TITLE
adds syntax highlights to ExDoc buffers when `!alchemist#ansi_enabled()`

### DIFF
--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -172,7 +172,7 @@ function! s:open_doc_window(query, newposition, position)
     if match(a:query, "^:") ==# 0
         setlocal ft=man
     elseif !alchemist#ansi_enabled()
-        setlocal ft=markdown
+        setlocal ft=exdoc
     endif
 
     noremap <silent> <buffer> q :call <SID>close_doc_win()<cr>

--- a/syntax/exdoc.vim
+++ b/syntax/exdoc.vim
@@ -1,0 +1,12 @@
+syntax match ExDocHeading /\v^*.+$/
+syntax match ExDocSection /\v^#+.+$/
+syntax match ExDocQuoted  /`.\{-}`/
+syntax match ExDocCode    /\v^\s{4}.+$/
+
+syntax region ExDocListItem start=/\v^\s{2}\*/ end=/\v^\s*$/ contains=ExDocQuoted
+
+highlight link ExDocHeading Keyword
+highlight link ExDocSection Keyword
+highlight link ExDocQuoted  Identifier
+highlight link ExDocCode    Identifier
+highlight link ExDocListItem Normal

--- a/syntax/exdoc.vim
+++ b/syntax/exdoc.vim
@@ -5,8 +5,8 @@ syntax match ExDocCode    /\v^\s{4}.+$/
 
 syntax region ExDocListItem start=/\v^\s{2}\*/ end=/\v^\s*$/ contains=ExDocQuoted
 
-highlight link ExDocHeading Keyword
-highlight link ExDocSection Keyword
-highlight link ExDocQuoted  Identifier
-highlight link ExDocCode    Identifier
+highlight ExDocHeading guifg=#edddb6 gui=bold ctermfg=223 cterm=bold
+highlight ExDocSection guifg=#edddb6 gui=bold ctermfg=223 cterm=bold
+highlight ExDocQuoted  guifg=#97d2d5 ctermfg=195
+highlight ExDocCode    guifg=#97d2d5 ctermfg=195
 highlight link ExDocListItem Normal


### PR DESCRIPTION
Made this change locally a few days ago - committing and opening a PR in case others would find it useful.

This change adds a simple syntax file for ExDoc buffers and enables it when the user
opens `ExDoc` and does not have `AnsiExec`. Previously, the ExDoc buffer relied on `markdown` syntax highlighting.

It covers some basic cases - code blocks, section headers etc - but I'm sure there are some edge cases it misses.

Below is a screenshot with an `ExDoc` buffer on the left and `iex` on the right.

![screen shot 2017-03-19 at 19 55 47](https://cloud.githubusercontent.com/assets/8920322/24084252/7ed470c2-0cde-11e7-951d-d4a7d0e847e1.png)
