### PR TITLE
Allow disabling and redefining mapping

### DIFF
--- a/after/ftplugin/elixir.vim
+++ b/after/ftplugin/elixir.vim
@@ -21,7 +21,10 @@ if exists('&omnifunc') && g:alchemist#omnifunc
 endif
 
 runtime! ftplugin/man.vim
-nnoremap <buffer> <silent> K :call alchemist#exdoc()<CR>
+
+if !exists('g:alchemist_mappings_disable')
+    nnoremap <buffer> <silent> K :call alchemist#exdoc()<CR>
+endif
 
 if !exists('g:alchemist_tag_disable')
     if !exists('g:alchemist_tag_map') | let g:alchemist_tag_map = '<C-]>' | en

--- a/after/ftplugin/elixir.vim
+++ b/after/ftplugin/elixir.vim
@@ -23,7 +23,8 @@ endif
 runtime! ftplugin/man.vim
 
 if !exists('g:alchemist_mappings_disable')
-    nnoremap <buffer> <silent> K :call alchemist#exdoc()<CR>
+    if !exists('g:alchemist_keyword_map') | let g:alchemist_keyword_map = 'K' | en
+    exe 'nnoremap <buffer> <silent> ' . g:alchemist_keyword_map . ' :call alchemist#exdoc()<CR>'
 endif
 
 if !exists('g:alchemist_tag_disable')

--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -138,7 +138,8 @@ function! s:open_doc_window(query, newposition, position)
         sil file `="[ExDoc]"`
         let s:buf_nr = bufnr('%')
         if !exists('g:alchemist_mappings_disable')
-            nnoremap <buffer> <silent> K :call alchemist#exdoc()<CR>
+            if !exists('g:alchemist_keyword_map') | let g:alchemist_keyword_map = 'K' | en
+            exe 'nnoremap <buffer> <silent> ' . g:alchemist_keyword_map . ' :call alchemist#exdoc()<CR>'
         endif
         if alchemist#ansi_enabled()
             AnsiEsc

--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -137,7 +137,9 @@ function! s:open_doc_window(query, newposition, position)
         execute a:newposition
         sil file `="[ExDoc]"`
         let s:buf_nr = bufnr('%')
-        nnoremap <buffer> <silent> K :call alchemist#exdoc()<CR>
+        if !exists('g:alchemist_mappings_disable')
+            nnoremap <buffer> <silent> K :call alchemist#exdoc()<CR>
+        endif
         if alchemist#ansi_enabled()
             AnsiEsc
         endif

--- a/doc/alchemist.txt
+++ b/doc/alchemist.txt
@@ -22,6 +22,7 @@ CONTENTS                                                   *AlchemistContents*
       4.5 g:alchemist#elixir_erlang_src
       4.6 g:alchemist_iex_term_size
       4.7 g:alchemist_iex_term_split
+      4.8 g:alchemist_mappings_disable
     5. License...................|AlchemistLicense|
     6. Bugs......................|AlchemistBugs|
     7. Contributing..............|AlchemistContributing|
@@ -87,6 +88,10 @@ Default: current directory
 ------------------------------------------------------------------------------
 4.7 g:alchemist_iex_term_split
 
+------------------------------------------------------------------------------
+4.8 g:alchemist_mappings_disable
+
+Do not add a mapping for the documentation lookup functionality.
 
 ==============================================================================
 5. License                                                  *AlchemistLicense*

--- a/doc/alchemist.txt
+++ b/doc/alchemist.txt
@@ -23,6 +23,7 @@ CONTENTS                                                   *AlchemistContents*
       4.6 g:alchemist_iex_term_size
       4.7 g:alchemist_iex_term_split
       4.8 g:alchemist_mappings_disable
+      4.9 g:alchemist_keyword_map
     5. License...................|AlchemistLicense|
     6. Bugs......................|AlchemistBugs|
     7. Contributing..............|AlchemistContributing|
@@ -92,6 +93,13 @@ Default: current directory
 4.8 g:alchemist_mappings_disable
 
 Do not add a mapping for the documentation lookup functionality.
+
+------------------------------------------------------------------------------
+4.9 g:alchemist_keyword_map
+
+Sets the normal mode mapping for opening the documentation. Example:
+
+    let g:alchemist_keyword_map = '<leader>K'
 
 ==============================================================================
 5. License                                                  *AlchemistLicense*


### PR DESCRIPTION
This PR adds the option to do the following things:

1. Disable the default mapping for looking up a keyword under the cursor in the documentation.
2. Configure the mapping for the lookup.

I'm not not entirely sure this is how @slashmili would like the code to look so I'm open to suggestions when it comes to changes!

Closes #91.