### PR TITLE
Deoplete remote plugin truncates the last completion

### DIFF
--- a/rplugin/python3/deoplete/sources/alchemist.py
+++ b/rplugin/python3/deoplete/sources/alchemist.py
@@ -29,7 +29,7 @@ class Source(Base):
         with Popen([client, cwd_opt], stdin=PIPE, stdout=PIPE) as proc:
             results = proc.communicate(input=request)[0].decode()
 
-        return self.__get_suggestions__(results.split('\n')[:-2])
+        return self.__get_suggestions__(results.split('\n')[:-1])
 
     # Private implementation
     ########################


### PR DESCRIPTION
Currently, the deoplete remote plugin for alchemist.vim appears to truncate the last completion from the list. I've done my best to illustrate the issue I'm seeing below in images and alchemist-server communications. From looking at the code, it appears that the `-2` in the split should in fact be a `-1`. I've also opened an [Issue](https://github.com/slashmili/alchemist.vim/issues/103) for this PR.

## Current Behavior (split on `-2`)
![Current Behavior](http://imgur.com/hyHGdqa.jpg)


### Full server response
```
"kind:f, word:Sandbox.functionA, abbr:functionA/1\nkind:f, word:Sandbox.functionB, abbr:functionB/2\nkind:f, word:Sandbox.functionC, abbr:functionC/3\nEND-OF-COMPX"
```

### Split response

```
[ "kind:f, word:Sandbox.functionA, abbr:functionA/1", 
  "kind:f, word:Sandbox.functionB, abbr:functionB/2" ]
```

## After fix (split on `-1`)
![Behavior after fix](http://imgur.com/1Kjfl0C.jpg)

### Full server response
```
"kind:f, word:Sandbox.functionA, abbr:functionA/1\nkind:f, word:Sandbox.functionB, abbr:functionB/2\nkind:f, word:Sandbox.functionC, abbr:functionC/3\nEND-OF-COMPX"
```

### Split response

```
[ "kind:f, word:Sandbox.functionA, abbr:functionA/1", 
  "kind:f, word:Sandbox.functionB, abbr:functionB/2",
  "kind:f, word:Sandbox.functionC, abbr:functionC/3" ]
```