### PR TITLE
Use hi link for exdoc syntax rather than explicit colors

### DIFF
--- a/syntax/exdoc.vim
+++ b/syntax/exdoc.vim
@@ -1,12 +1,20 @@
-syntax match ExDocHeading /\v^*.+$/
-syntax match ExDocSection /\v^#+.+$/
-syntax match ExDocQuoted  /`.\{-}`/
-syntax match ExDocCode    /\v^\s{4}.+$/
+syntax include @ELIXIR syntax/elixir.vim
 
-syntax region ExDocListItem start=/\v^\s{2}\*/ end=/\v^\s*$/ contains=ExDocQuoted
+syn match  ExDocHeading /\v^*.+$/ contains=ExDocHeadingMarker
+syn match  ExDocHeadingMarker /\v^*/ contained
+syn match  ExDocSection /\v^#+.+$/ contains=ExDocSectionMarker
+syn match  ExDocSectionMarker /\v^#+/ contained
+syn match  ExDocQuoted  /`.\{-}`/
+syn match  ExDocCode /\v^\s{4}((iex)|(\.{3})\>)@!.*$/ contains=@ELIXIR
+syn region ExDocListItem start=/\v^\s{2}\*/ end=/\v^\s*$/ contains=ExDocQuoted
+" TODO, not working
+" syn match  ExDocExample /\v^\s{4}((iex)|(\.{3})\>)@=.*$/ contains=ExDocIEx,@ELIXIR
+" syn match  ExDocIEx /\v^\s{4}((iex)|(\.{3})\>)/ contained
 
-highlight ExDocHeading guifg=#edddb6 gui=bold ctermfg=223 cterm=bold
-highlight ExDocSection guifg=#edddb6 gui=bold ctermfg=223 cterm=bold
-highlight ExDocQuoted  guifg=#97d2d5 ctermfg=195
-highlight ExDocCode    guifg=#97d2d5 ctermfg=195
-highlight link ExDocListItem Normal
+hi def link ExDocHeading       Title
+hi def link ExDocHeadingMarker Comment
+hi def link ExDocSectionMarker Comment
+hi def link ExDocSection       Title
+hi def link ExDocQuoted        string
+hi def link ExDocListItem      Normal
+" hi def link ExDocIEx           Comment


### PR DESCRIPTION
Using explicit colors in syntax highlighting is poor form in general,
and for these colors especially doesn't look awesome on my color scheme
(solarized light). This commit changes the highlighting to instead link
to some highlight groups that are built into vim so that the colors
remain consistent, and adds embedded syntax highlighting of elixir code
for good measure

I attempted to add highlighting of IEx examples here but wasn't able to
get it working - the code I wrote for that is left here in case someone
can get it working in the future

----------------

Before:
<img width="620" alt="screenshot 2017-08-07 13 18 52" src="https://user-images.githubusercontent.com/1481027/29037753-01b63d9c-7b73-11e7-89c1-b5dc85cc2634.png">

After:
<img width="623" alt="screenshot 2017-08-07 13 19 49" src="https://user-images.githubusercontent.com/1481027/29037775-1d41be60-7b73-11e7-8067-7135b00a18b4.png">
