### PR TITLE
Update .gitignore to add tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /_build
 /cover
 /deps
+/doc/tags
+tags
 erl_crash.dump
 *.ez
 *.sw?


### PR DESCRIPTION
`doc/tags` gets auto-created upon plugin install (using Vundle). When using git submodules, the existence of `doc/tags` causes git errors indicating untracked content. Noticed that many other vim plugins account for this, and add `tags` or `doc/tags` to their .gitignore files - for example [nerdcommenter](https://github.com/scrooloose/nerdcommenter/blob/master/.gitignore) or [tabular](https://github.com/godlygeek/tabular/blob/master/.gitignore).  Have about 60 plugins, and only 4 currently missing `tags` in their .gitignore - please consider accepting this PR.