### PR TITLE
Prevent last line of docs from being removed

### DIFF
--- a/after/plugin/alchemist.vim
+++ b/after/plugin/alchemist.vim
@@ -166,8 +166,7 @@ function! s:open_doc_window(query, newposition, position)
     setlocal modifiable
     setlocal noreadonly
     %delete _
-    call append(0, split(content, "\n"))
-    sil $delete _
+    call append(0, alchemist#trim_doc(content))
     sil $delete _
     normal gg
 
@@ -538,6 +537,17 @@ function! alchemist#mix_complete(ArgLead, CmdLine, CursorPos, ...)
     execute 'lcd ' . fnameescape(old_cwd)
   endif
   return g:mix_tasks
+endfunction
+
+function! alchemist#trim_doc(content)
+    let l:lines = split(a:content, "\n")
+    let l:end_index = len(l:lines) - 1
+
+    while l:end_index > 0 && empty(l:lines[l:end_index])
+        let l:end_index -= 1
+    endwhile
+
+    return l:lines[:l:end_index]
 endfunction
 
 command! -nargs=? -complete=customlist,elixircomplete#ex_doc_complete ExDoc


### PR DESCRIPTION
Should fix #142

Here's the flow, as I understand it:

- buffer is emptied
- contents of docs is appended to file
- last two lines are removed

Based on the contents of the docs, that may remove legitimate text.  Instead of trying to guess / detect how much whitespace there is, this will just remove empty lines from the end. I've left one line deletion after we append, since appending always adds an empty line.  The only other explanation I could come up with was to trim the erlang docs, which append another line of text to all entries. This will not do that.

I tested this against:

- my own custom elixir modules
- a built in elixir module (Map.get)
- erlang module lookups